### PR TITLE
fix magic-number

### DIFF
--- a/python_cli_demo/tts.py
+++ b/python_cli_demo/tts.py
@@ -80,9 +80,9 @@ async def transferMsTTSData(SSML_text, outputPath):
                 if type(response) == type(bytes()):
                     # Extract binary data
                     try:
-                        start_ind = str(response).find('Path:audio')
-                        #audio_string += str(response)[start_ind+14:-1]
-                        audio_stream += response[start_ind-2:]
+                        needle = b'Path:audio\r\n'
+                        start_ind = response.find(needle) + len(needle)
+                        audio_stream += response[start_ind:]
                     except:
                         pass
             else:


### PR DESCRIPTION
The last `response` is `b'\x00gX-RequestId:E373ACC10B9647D8BC047C04EB3D05B0\r\nX-StreamId:3FED2B4B2FDB4C878F251D2ED23304A9\r\nPath:audio\r\n'`, and the offset of mp3 should be `105` instead of `100`